### PR TITLE
Hotfix 1.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,22 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.1.1 (2021-07-20)
+------------------
+
+**Added**
+
+**Fixed**
+
+* Remove NanoporeParser to fix ``GroovyCastException`` (`#17 <https://github.com/qbicsoftware/java-openbis-dropboxes/pull/17>`_)
+
+**Dependencies**
+
+* Increase version for ``life.qbic:core-utils-lib`` from ``1.9.0-> 1.9.1``
+
+**Deprecated**
+
+
 1.1.0 (2021-07-19)
 ------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>java-openbis-dropboxes</artifactId>
-  <version>1.1.0-SNAPSHOT</version> <!-- <<QUBE_FORCE_BUMP>> -->
+  <version>1.1.1-SNAPSHOT</version> <!-- <<QUBE_FORCE_BUMP>> -->
   <groupId>life.qbic</groupId>
   <name>OpenBIS ETL routines written in Java</name>
   <url>http://github.com/qbicsoftware/java-openbis-dropboxes</url>
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>life.qbic</groupId>
       <artifactId>core-utils-lib</artifactId>
-      <version>1.9.0</version>
+      <version>1.9.1</version>
     </dependency>
     <dependency>
       <groupId>org.spockframework</groupId>

--- a/src/main/groovy/life/qbic/registration/MainETL.groovy
+++ b/src/main/groovy/life/qbic/registration/MainETL.groovy
@@ -19,8 +19,7 @@ class MainETL extends AbstractJavaDataSetRegistrationDropboxV2 {
 
     static List<DatasetParser<?>> listOfParsers = [
             new BioinformaticAnalysisParser(),
-            new MaxQuantParser(),
-            new NanoporeParser()
+            new MaxQuantParser()
     ] as List<DatasetParser<?>>
 
     @Override


### PR DESCRIPTION
1.1.1 (2021-07-20)
------------------

**Added**

**Fixed**

* Remove NanoporeParser to fix ``GroovyCastException`` (`#17 <https://github.com/qbicsoftware/java-openbis-dropboxes/pull/17>`_)

**Dependencies**

* Increase version for ``life.qbic:core-utils-lib`` from ``1.9.0-> 1.9.1``

**Deprecated**