### PR TITLE
Identify datasets in nested structures

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 **Added**
 
 * New DatasetLocator, that helps with the identification of the actual dataset folder in cases of complex nested structures
+* Increased verbosity in logging parser errors
 
 **Fixed**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
-1.3.0 (2022-01-20)
+1.2.0 (2022-01-20)
 ------------------
 
 **Added**
@@ -17,17 +17,6 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Deprecated**
 
-
-1.2.0 (2021-09-14)
-------------------
-
-**Added**
-
-**Fixed**
-
-**Dependencies**
-
-**Deprecated**
 
 1.1.5 (2021-09-14)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,20 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.3.0 (2022-01-20)
+------------------
+
+**Added**
+
+* New DatasetLocator, that helps with the identification of the actual dataset folder in cases of complex nested structures
+
+**Fixed**
+
+**Dependencies**
+
+**Deprecated**
+
+
 1.2.0 (2021-09-14)
 ------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>java-openbis-dropboxes</artifactId>
-  <version>1.2.0-SNAPSHOT</version> <!-- <<QUBE_FORCE_BUMP>> -->
+  <version>1.3.0-SNAPSHOT</version> <!-- <<QUBE_FORCE_BUMP>> -->
   <groupId>life.qbic</groupId>
   <name>OpenBIS ETL routines written in Java</name>
   <url>http://github.com/qbicsoftware/java-openbis-dropboxes</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>java-openbis-dropboxes</artifactId>
-  <version>1.3.0-SNAPSHOT</version> <!-- <<QUBE_FORCE_BUMP>> -->
+  <version>1.2.0-SNAPSHOT</version> <!-- <<QUBE_FORCE_BUMP>> -->
   <groupId>life.qbic</groupId>
   <name>OpenBIS ETL routines written in Java</name>
   <url>http://github.com/qbicsoftware/java-openbis-dropboxes</url>

--- a/src/main/groovy/life/qbic/registration/handler/DatasetLocator.groovy
+++ b/src/main/groovy/life/qbic/registration/handler/DatasetLocator.groovy
@@ -1,0 +1,36 @@
+package life.qbic.registration.handler
+
+/**
+ * Returns the actual dataset folder in cases of complex datastructures,
+ * that have been created upon data transfer and has been pre-processed
+ * by the dropboxhandler.
+ *
+ * The Dropbhoxhandler wraps the actual dataset in another folder and provides additional
+ * data, like checksums and the original incoming dropbox aka the client institution that has transferred
+ * the dataset in the first place.
+ *
+ * Example:
+ *
+ *  |- mydataset_folder
+ *         |- data1.txt
+ *         |- data2.txt
+ *
+ *  becomes:
+ *
+ *  |- mydataset_folder
+ *      |- source_dropbox.txt
+ *      |- mydataset_folder
+ *            |- data1.txt
+ *            |- data2.txt
+ *
+ * @since
+ */
+interface DatasetLocator {
+
+    /**
+     * Returns the top level absolute path of the dataset. In a flat structure, it returns
+     * the top level folder, in the assumption that the dataset folder is not nested.
+     * @return the absolute dataset folder path
+     */
+    String getPathToDatasetFolder()
+}

--- a/src/main/groovy/life/qbic/registration/handler/DatasetLocatorImpl.groovy
+++ b/src/main/groovy/life/qbic/registration/handler/DatasetLocatorImpl.groovy
@@ -33,7 +33,7 @@ class DatasetLocatorImpl implements DatasetLocator{
      */
     @Override
     String getPathToDatasetFolder() {
-        return findNestedDataset().orElseGet(() -> rootPath)
+        return findNestedDataset().orElse(this.rootPath)
     }
 
     private Optional<String> findNestedDataset() {

--- a/src/main/groovy/life/qbic/registration/handler/DatasetLocatorImpl.groovy
+++ b/src/main/groovy/life/qbic/registration/handler/DatasetLocatorImpl.groovy
@@ -38,6 +38,8 @@ class DatasetLocatorImpl implements DatasetLocator{
 
     private Optional<String> findNestedDataset() {
         File rootDir = new File(rootPath)
+        if (!rootDir.isDirectory())
+            return Optional.empty()
         String dirName = rootDir.getName()
         /*
         Now we iterate through the list of child elements in the folder, and search for the directory name appearances.

--- a/src/main/groovy/life/qbic/registration/handler/DatasetLocatorImpl.groovy
+++ b/src/main/groovy/life/qbic/registration/handler/DatasetLocatorImpl.groovy
@@ -1,0 +1,58 @@
+package life.qbic.registration.handler
+
+/**
+ * <b>DatasetLocatorImpl Class</b>
+ *
+ * <p>Finds nested datasets.</p>
+ *
+ * @since 1.3.0
+ */
+class DatasetLocatorImpl implements DatasetLocator{
+
+    private final String rootPath
+
+    /**
+     * Creates an instance of a {@link DatasetLocator}.
+     * @param rootPath - must be an absolute path to the top level directory of the data-structure under investigation
+     */
+    static of(String rootPath) {
+        if (!rootPath || !isAbsolutePath(rootPath)) {
+            throw new IllegalArgumentException("You must provide an absolute path. Provided: $rootPath")
+        }
+        return new DatasetLocatorImpl(rootPath)
+    }
+
+    private DatasetLocatorImpl(String rootPath) {
+        this.rootPath = rootPath
+    }
+
+    private DatasetLocatorImpl(){}
+
+    /**
+     * @inheritDocs
+     */
+    @Override
+    String getPathToDatasetFolder() {
+        return findNestedDataset().orElseGet(() -> rootPath)
+    }
+
+    private Optional<String> findNestedDataset() {
+        File rootDir = new File(rootPath)
+        String dirName = rootDir.getName()
+        /*
+        Now we iterate through the list of child elements in the folder, and search for the directory name appearances.
+        If it is a child directory, that means it has been processed with the dropboxhandler and
+        we can return the nested dataset path.
+        */
+        for (String child : rootDir.list()) {
+            if (child.equalsIgnoreCase(dirName)) {
+                return Optional.of(rootDir.getAbsolutePath() + "/" + child)
+            }
+        }
+        return Optional.empty()
+    }
+
+    private static boolean isAbsolutePath(String path) {
+        return new File(path).isAbsolute()
+    }
+}

--- a/src/main/groovy/life/qbic/registration/handler/DatasetParserHandler.groovy
+++ b/src/main/groovy/life/qbic/registration/handler/DatasetParserHandler.groovy
@@ -27,7 +27,7 @@ class DatasetParserHandler {
     /**
      * Provides access to all observed exceptions during the prude force parsing attempt
      */
-    final List<Exception> observedExceptions
+    final Map<String, Exception> observedExceptions
 
     /**
      * Creates an instance of a parser handler object with a given list of
@@ -38,7 +38,7 @@ class DatasetParserHandler {
     DatasetParserHandler(List<DatasetParser<?>> listOfParsers) {
         Objects.requireNonNull(listOfParsers, "List must not be null.")
         dataSetParserList = listOfParsers
-        observedExceptions = []
+        observedExceptions = [:]
     }
 
     /**
@@ -63,13 +63,13 @@ class DatasetParserHandler {
         Iterator<DatasetParser> dataSetIterator = dataSetParserList.iterator()
         Optional<?> result = Optional.empty()
         while (dataSetIterator.hasNext()) {
+            DatasetParser parser = dataSetIterator.next()
             try {
-                DatasetParser parser = dataSetIterator.next()
                 result = Optional.of(parser.parseFrom(root))
             } catch (DataParserException e) {
-                observedExceptions << e
+                observedExceptions.put(parser.getClass().getCanonicalName(), e)
             } catch (DatasetValidationException e){
-                observedExceptions << e
+                observedExceptions.put(parser.getClass().getCanonicalName(), e)
             }
             if (result.isPresent())
                 return result

--- a/src/test/groovy/life/qbic/registration/handler/DatasetLocatorImplSpec.groovy
+++ b/src/test/groovy/life/qbic/registration/handler/DatasetLocatorImplSpec.groovy
@@ -1,0 +1,87 @@
+package life.qbic.registration.handler
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * <b><class short description - 1 Line!></b>
+ *
+ * <p><More detailed description - When to use, what it solves, etc.></p>
+ *
+ * @since <version tag>
+ */
+class DatasetLocatorImplSpec extends Specification {
+
+    @Shared
+    String nestedDataStructureExample
+
+    @Shared
+    String relativePathExample
+
+    @Shared
+    String flatDataStructureExample
+
+    def setup() {
+        setupNestedDataset()
+        setupRelativePathExample()
+        setupFlatDatasetExample()
+    }
+
+    def "Non absolute path shall return an IllegalArgumentException"() {
+        when:
+        DatasetLocator locator = DatasetLocatorImpl.of(relativePathExample)
+
+        then:
+        thrown(IllegalArgumentException.class)
+    }
+
+    def "Given an absolute path shall successfully create an instance of this class"() {
+        when:
+        DatasetLocator locator = DatasetLocatorImpl.of(nestedDataStructureExample)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "Given an nested structure, return the actual dataset absolute path"() {
+        given:
+        DatasetLocator locator = DatasetLocatorImpl.of(nestedDataStructureExample)
+
+        when:
+        String datasetPath = locator.getPathToDatasetFolder()
+
+        then:
+        datasetPath != nestedDataStructureExample
+
+        new File(datasetPath).getParent().equalsIgnoreCase(nestedDataStructureExample)
+    }
+
+    def "Given an flat structure, return the actual root dataset absolute path"() {
+        given:
+        DatasetLocator locator = DatasetLocatorImpl.of(flatDataStructureExample)
+
+        when:
+        String datasetPath = locator.getPathToDatasetFolder()
+
+        then:
+        datasetPath == flatDataStructureExample
+    }
+
+    def setupNestedDataset() {
+        File file = File.createTempDir()
+        new File(file.getAbsolutePath() + File.separator + file.getName()).createNewFile()
+        nestedDataStructureExample = file.getAbsolutePath()
+    }
+
+    def setupRelativePathExample() {
+        File file = File.createTempDir()
+        relativePathExample = file.getName()
+    }
+
+    def setupFlatDatasetExample() {
+        File file = File.createTempDir()
+        new File(file.getAbsolutePath() + File.separator + "myAwesomeDataset").createNewFile()
+        flatDataStructureExample = file.getAbsolutePath()
+    }
+
+}


### PR DESCRIPTION
This PR introduces a DatasetLocatorImpl class, that enables the ETL
to grab the actual dataset path in case of nested structures, generated after processing with the Dropboxhandler.

