### PR TITLE
remove hidden files in the file structure before registration

### DIFF
--- a/src/main/groovy/life/qbic/registration/MainETL.groovy
+++ b/src/main/groovy/life/qbic/registration/MainETL.groovy
@@ -41,7 +41,7 @@ class MainETL extends AbstractJavaDataSetRegistrationDropboxV2 {
 
         DatasetCleaner cleaner = new HiddenFilesCleaner()
         try {
-            cleaner.removeUnwantedFiles(Paths.get(pathToDatasetFolder))
+            cleaner.clean(Paths.get(pathToDatasetFolder))
         } catch (IOException e) {
             log.error(e.getMessage())
             throw new RegistrationException("Error when deleting hidden file.")

--- a/src/main/groovy/life/qbic/registration/MainETL.groovy
+++ b/src/main/groovy/life/qbic/registration/MainETL.groovy
@@ -39,6 +39,14 @@ class MainETL extends AbstractJavaDataSetRegistrationDropboxV2 {
             throw new RegistrationException("Data structure could not be parsed.")
         })
 
+        DatasetCleaner cleaner = new HiddenFilesCleaner()
+        try {
+            cleaner.removeUnwantedFiles(Paths.get(pathToDatasetFolder))
+        } catch (IOException e) {
+            log.error(e.getMessage())
+            throw new RegistrationException("Error when deleting hidden file.")
+        }
+
         Registry registry =  RegistrationHandler.getRegistryFor(concreteResult).orElseThrow(
                 {
                     throw new RegistrationException("No registry found for data structure.")

--- a/src/main/groovy/life/qbic/registration/handler/DatasetCleaner.groovy
+++ b/src/main/groovy/life/qbic/registration/handler/DatasetCleaner.groovy
@@ -16,5 +16,4 @@ interface DatasetCleaner {
      */
     void removeUnwantedFiles(Path root)
 
-
 }

--- a/src/main/groovy/life/qbic/registration/handler/DatasetCleaner.groovy
+++ b/src/main/groovy/life/qbic/registration/handler/DatasetCleaner.groovy
@@ -1,0 +1,20 @@
+package life.qbic.registration.handler
+
+import java.nio.file.Path
+
+/**
+ * Removes unwanted files from a file structure
+ *
+ * @since 1.5.0
+ */
+interface DatasetCleaner {
+    /**
+     * <p>Tries to remove unwanted files from a file structure.<p>
+     *
+     * @param root the top level path of the directory with the file structure to be parsed.
+     * @since 1.5.0
+     */
+    void removeUnwantedFiles(Path root)
+
+
+}

--- a/src/main/groovy/life/qbic/registration/handler/DatasetCleaner.groovy
+++ b/src/main/groovy/life/qbic/registration/handler/DatasetCleaner.groovy
@@ -11,9 +11,9 @@ interface DatasetCleaner {
     /**
      * <p>Tries to remove unwanted files from a file structure.<p>
      *
-     * @param root the top level path of the directory with the file structure to be parsed.
+     * @param datasetRoot the top level path of the directory with the file structure to be cleaned.
      * @since 1.5.0
      */
-    void removeUnwantedFiles(Path root)
+    void clean(Path datasetRoot)
 
 }

--- a/src/main/groovy/life/qbic/registration/handler/HiddenFilesCleaner.groovy
+++ b/src/main/groovy/life/qbic/registration/handler/HiddenFilesCleaner.groovy
@@ -1,0 +1,24 @@
+package life.qbic.registration.handler
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class HiddenFilesCleaner implements DatasetCleaner {
+
+
+    /**
+     * <p>Tries to remove unwanted, hidden files from a file structure.<p>
+     *
+     * @param root the top level path of the directory with the file structure to be parsed.
+     * @since 1.5.0
+     */
+    @Override
+    void removeUnwantedFiles(Path root) {
+            Files.walk(root).forEach(path -> {
+                if(path.toFile().isHidden()) {
+                    path.toFile().delete()
+                }
+            })
+    }
+}

--- a/src/main/groovy/life/qbic/registration/handler/HiddenFilesCleaner.groovy
+++ b/src/main/groovy/life/qbic/registration/handler/HiddenFilesCleaner.groovy
@@ -10,11 +10,11 @@ class HiddenFilesCleaner implements DatasetCleaner {
     /**
      * <p>Tries to remove unwanted, hidden files from a file structure.<p>
      *
-     * @param root the top level path of the directory with the file structure to be parsed.
+     * @param datasetRoot the top level path of the directory with the file structure to be parsed.
      * @since 1.5.0
      */
     @Override
-    void removeUnwantedFiles(Path root) {
+    void clean(Path datasetRoot) {
             Files.walk(root).forEach(path -> {
                 if(path.toFile().isHidden()) {
                     path.toFile().delete()

--- a/src/main/groovy/life/qbic/registration/handler/HiddenFilesCleaner.groovy
+++ b/src/main/groovy/life/qbic/registration/handler/HiddenFilesCleaner.groovy
@@ -15,7 +15,7 @@ class HiddenFilesCleaner implements DatasetCleaner {
      */
     @Override
     void clean(Path datasetRoot) {
-            Files.walk(root).forEach(path -> {
+            Files.walk(datasetRoot).forEach(path -> {
                 if(path.toFile().isHidden()) {
                     path.toFile().delete()
                 }

--- a/src/test/groovy/life/qbic/registration/handler/HiddenFilesCleanerSpec.groovy
+++ b/src/test/groovy/life/qbic/registration/handler/HiddenFilesCleanerSpec.groovy
@@ -43,7 +43,7 @@ class HiddenFilesCleanerSpec extends Specification {
         visibleFiles.add(level3)
 
         when:
-        cleaner.removeUnwantedFiles(tempDir.toPath())
+        cleaner.clean(tempDir.toPath())
 
         then: "the result must not contain the hidden file, but all other files"
         for (File hidden : hiddenFiles) {

--- a/src/test/groovy/life/qbic/registration/handler/HiddenFilesCleanerSpec.groovy
+++ b/src/test/groovy/life/qbic/registration/handler/HiddenFilesCleanerSpec.groovy
@@ -1,0 +1,56 @@
+package life.qbic.registration.handler
+
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+class HiddenFilesCleanerSpec extends Specification {
+
+    def "Give a folder structure with and without hidden files, the hidden files cleaner removes only hidden files"() {
+        given: "A DatasetCleaner that removes Hidden Files"
+        DatasetCleaner cleaner = new HiddenFilesCleaner()
+        List<File> hiddenFiles = new ArrayList<>()
+        List<File> visibleFiles = new ArrayList<>()
+
+        Path tempDirPath = Files.createTempDirectory("20220615101241_maxquant_results_QABCDR03R14_Exp1Phospho")
+        File tempDir = tempDirPath.toFile()
+
+        hiddenFiles.add(File.createTempFile("._QABCD_sample_ids", ".txt", tempDir))
+        hiddenFiles.add(File.createTempFile("._.DS_Store", "", tempDir))
+        hiddenFiles.add(File.createTempFile(".DS_Store", "", tempDir))
+
+        visibleFiles.add(tempDir)
+        visibleFiles.add(File.createTempFile("mqpar", ".xml", tempDir))
+        visibleFiles.add(File.createTempFile("QABCD_sample_ids", ".txt", tempDir))
+
+        Path level2Path = Files.createTempDirectory(tempDirPath,"txt")
+        File level2 = level2Path.toFile()
+        visibleFiles.add(level2)
+        visibleFiles.add(File.createTempFile("allPeptides", ".txt", level2))
+        visibleFiles.add(File.createTempFile("evidence", ".txt", level2))
+        visibleFiles.add(File.createTempFile("experimentalDesignTemplate", ".txt", level2))
+        visibleFiles.add(File.createTempFile("libraryMatch", ".txt", level2))
+        visibleFiles.add(File.createTempFile("matchedFeatures", ".txt", level2))
+        visibleFiles.add(File.createTempFile("mzTab", ".mzTab", level2))
+        visibleFiles.add(File.createTempFile("peptides", ".txt", level2))
+        visibleFiles.add(File.createTempFile("proteinGroups", ".txt", level2))
+        visibleFiles.add(File.createTempFile("summary", ".txt", level2))
+        visibleFiles.add(File.createTempFile("tables", ".pdf", level2))
+
+        File level3 = Files.createTempDirectory(level2Path, "summary").toFile()
+        visibleFiles.add(File.createTempFile("PhosphoSites_nonredundant", ".txt", level3))
+        visibleFiles.add(level3)
+
+        when:
+        cleaner.removeUnwantedFiles(tempDir.toPath())
+
+        then: "the result must not contain the hidden file, but all other files"
+        for (File hidden : hiddenFiles) {
+            assert !hidden.exists()
+        }
+        for (File visible : visibleFiles) {
+            assert visible.exists()
+        }
+    }
+}


### PR DESCRIPTION
Removes all hidden files in the file structure of a dataset, as they are often added when browsing the data in different OS utilities.